### PR TITLE
Add remark compatibility

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,65 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: "Deep learning for solving dynamic economic models\0"
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Lilia
+    family-names: Maliar
+    affiliation: >-
+      a The Graduate Center, City University of New York,
+      CEPR, and Hoover Institution, Stanford University
+  - given-names: Serguei
+    family-names: Maliar
+    affiliation: Santa Clara University
+  - given-names: Pablo
+    family-names: Winant
+    affiliation: ESCP Business School and CREST/Ecole Polytechnique
+identifiers:
+  - type: doi
+    value: 10.1016/j.jmoneco.2021.07.004
+repository-code: >-
+  https://github.com/marcmaliar/deep-learning-euler-method-krusell-smith/
+abstract: >-
+  We introduce a unified deep learning method that solves
+  dynamic economic models by casting them into nonlinear
+  regression equations. We derive such equations for three
+  fundamental objects of economic dynamics – lifetime reward
+  functions, Bellman equations and Euler equations. We
+  estimate the decision functions on simulated data using a
+  stochastic gradient descent method. We introduce an
+  all-in-one integration operator that facilitates
+  approximation of high-dimensional integrals. We use neural
+  networks to perform model reduction and to handle
+  multicollinearity. Our deep learning method is tractable
+  in large-scale problems, e.g., Krusell and Smith (1998).
+  We provide a TensorFlow code that accommodates a variety
+  of applications.
+keywords:
+  - Artificial intelligence
+  - Machine learning
+  - Deep learning
+  - Neural network
+  - Stochastic gradient
+  - Dynamic models
+  - Model reduction
+  - Dynamic programming
+  - Bellman equation
+  - Euler equation
+  - Value function
+references:
+  - type: article
+    authors:
+      - family-names: "Krusell"
+        given-names: "Per"
+      - family-names: "Smith, Jr."
+        given-names: "Anthony A."
+    title: "Income and Wealth Heterogeneity in the Macroeconomy"
+    doi: "10.1086/250034"
+    date-released: 1998-10-01
+    publisher:
+        name: "Journal of Political Economy"

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10.10
+  - matplotlib=3.7.1
+  - numpy=1.25.0
+  - tensorflow=2.13.1
+  - jupyter=1.0.0

--- a/reproduce.sh
+++ b/reproduce.sh
@@ -1,17 +1,3 @@
 #!/bin/bash
-# install the versioned required packages
-python -m venv venv
-source ./venv/bin/activate
-echo "Installing requirements.txt (Python packages)"
-pip install -r binder/requirements.txt --quiet
 
-# navigate to code/ and execute the python file to create figures
-#cd ./code/python
-jupyter nbconvert --to python ./code/python/Main_KS.ipynb --output Main_KS.py
-ipython ./code/python/Main_KS.py
-
-# Cleanup
-rm ./code/python/Main_KS.py
-#cd ../..
-deactivate
-#rm -rf venv
+jupyter execute ./code/python/Main_KS.ipynb

--- a/reproduce_jupyter.sh
+++ b/reproduce_jupyter.sh
@@ -1,16 +1,3 @@
 #!/bin/bash
-# install the versioned required packages
-python -m venv venv
-source ./venv/bin/activate
-echo "Installing requirements.txt (Python packages)"
-pip install -r binder/requirements_jupyter.txt --quiet
 
-# navigate to code/ and execute the python file to create figures
-# pip list
-#cd ./code/python
 jupyter notebook ./code/python/Main_KS.ipynb
-
-# Cleanup
-#cd ../..
-deactivate
-#rm -rf venv


### PR DESCRIPTION
- Add `binder/environment.yml` REMARK prefers the us of `conda` to `pip`
- Simplify the `reproduce*.sh` scripts.
    - The environment management code shouldn't exist in these locations, and have been removed.
- Add CITATION.cff file

These changes should be reviewed (particularly the CITATION.cff file) to ensure the information it contains is accurate.